### PR TITLE
Bump epoch for packages

### DIFF
--- a/py3-cloudkitty.yaml
+++ b/py3-cloudkitty.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cloudkitty
   description: Rating as a Service component for OpenStack
   version: 21.0.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-cmd2.yaml
+++ b/py3-cmd2.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cmd2
   description: cmd2 - quickly build feature-rich and user-friendly interactive command line applications in Python
   version: 2.4.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-confspirator.yaml
+++ b/py3-confspirator.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-confspirator
   description: A config library for handling nested incode config groups.
   version: 0.3.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-construct.yaml
+++ b/py3-construct.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-construct
   description: A powerful declarative symmetric parser/builder for binary data
   version: 2.10.70
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-coreapi.yaml
+++ b/py3-coreapi.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-coreapi
   description: Python client library for Core API.
   version: 2.3.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-coreschema.yaml
+++ b/py3-coreschema.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-coreschema
   description: Core Schema.
   version: 0.0.4
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-cotyledon.yaml
+++ b/py3-cotyledon.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cotyledon
   description: Cotyledon provides a framework for defining long-running services.
   version: 1.7.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-croniter.yaml
+++ b/py3-croniter.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-croniter
   description: croniter provides iteration for datetime object with cron like format
   version: 2.0.7
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cryptography
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   version: 42.0.8
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
     - license: BSD-2-Clause

--- a/py3-cursive.yaml
+++ b/py3-cursive.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cursive
   description: Cursive implements OpenStack-specific validation of digital signatures.
   version: 0.2.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-databases.yaml
+++ b/py3-databases.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-databases
   description: Async database support for Python.
   version: 0.9.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-datetimerange.yaml
+++ b/py3-datetimerange.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-datetimerange
   description: DateTimeRange is a Python library to handle a time range. e.g. check whether a time is within the time range, get the intersection of time ranges, truncate a time range, iterate through a time range, and so forth.
   version: 2.3.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-debtcollector.yaml
+++ b/py3-debtcollector.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-debtcollector
   description: A collection of Python deprecation patterns and strategies that help you collect your technical debt in a non-destructive manner.
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-decorator.yaml
+++ b/py3-decorator.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-decorator
   description: Decorators for Humans
   version: 5.1.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-defusedxml.yaml
+++ b/py3-defusedxml.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-defusedxml
   description: XML bomb protection for Python stdlib modules
   version: 0.7.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: PSF-2.0
   dependencies:

--- a/py3-designate.yaml
+++ b/py3-designate.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-designate
   description: DNS as a Service
   version: 19.0.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-diskimage-builder.yaml
+++ b/py3-diskimage-builder.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-diskimage-builder
   description: Golden Disk Image builder.
   version: 3.33.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-distro.yaml
+++ b/py3-distro.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-distro
   description: Distro - an OS platform information API
   version: 1.9.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-django-appconf.yaml
+++ b/py3-django-appconf.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-django-appconf
   description: A helper class for handling configuration defaults of packaged apps gracefully.
   version: 1.0.6
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-django-compressor.yaml
+++ b/py3-django-compressor.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-django-compressor
   description: ('Compresses linked and inline JavaScript or CSS into single cached files.',)
   version: 4.5.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-django-debreach.yaml
+++ b/py3-django-debreach.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-django-debreach
   description: Adds middleware to give some added protection against the BREACH attack in Django.
   version: 2.1.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-django-pyscss.yaml
+++ b/py3-django-pyscss.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-django-pyscss
   description: Makes it easier to use PySCSS in Django.
   version: 2.0.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-django-rest-swagger.yaml
+++ b/py3-django-rest-swagger.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-django-rest-swagger
   description: Swagger UI for Django REST Framework 3.5+
   version: 2.2.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-django.yaml
+++ b/py3-django.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-django
   description: A high-level Python web framework that encourages rapid development and clean, pragmatic design.
   version: 4.2.15
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-djangorestframework.yaml
+++ b/py3-djangorestframework.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-djangorestframework
   description: Web APIs for Django, made easy.
   version: 3.15.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-dnspython.yaml
+++ b/py3-dnspython.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-dnspython
   description: DNS toolkit
   version: 2.6.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: ISC
   dependencies:

--- a/py3-docker.yaml
+++ b/py3-docker.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-docker
   description: A Python library for the Docker Engine API.
   version: 7.1.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-dogpile-cache.yaml
+++ b/py3-dogpile-cache.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-dogpile-cache
   description: A caching front-end based on the Dogpile lock.
   version: 1.3.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-ecdsa.yaml
+++ b/py3-ecdsa.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-ecdsa
   description: ECDSA cryptographic signature library (pure python)
   version: 0.19.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-elasticsearch.yaml
+++ b/py3-elasticsearch.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-elasticsearch
   description: Python client for Elasticsearch
   version: 2.4.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-elementpath.yaml
+++ b/py3-elementpath.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-elementpath
   description: XPath 1.0/2.0/3.0/3.1 parsers and selectors for ElementTree and lxml
   version: 4.4.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-enmerkar.yaml
+++ b/py3-enmerkar.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-enmerkar
   description: Utilities for using Babel in Django
   version: 0.7.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-enum-compat.yaml
+++ b/py3-enum-compat.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-enum-compat
   description: enum/enum34 compatibility package
   version: 0.0.3
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-eventlet.yaml
+++ b/py3-eventlet.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-eventlet
   description: Highly concurrent networking library
   version: 0.36.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-exceptiongroup.yaml
+++ b/py3-exceptiongroup.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-exceptiongroup
   description: Backport of PEP 654 (exception groups)
   version: 1.2.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-falcon.yaml
+++ b/py3-falcon.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-falcon
   description: The ultra-reliable, fast ASGI+WSGI framework for building data plane APIs at scale.
   version: 3.1.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-fastapi.yaml
+++ b/py3-fastapi.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-fastapi
   description: FastAPI framework, high performance, easy to learn, fast to code, ready for production
   version: 0.58.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-fasteners.yaml
+++ b/py3-fasteners.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-fasteners
   description: A python package that provides useful locks
   version: 0.19
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-fixtures.yaml
+++ b/py3-fixtures.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-fixtures
   description: Fixtures, reusable state for writing clean tests and more.
   version: 4.1.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
     - license: Apache-2.0

--- a/py3-flake8.yaml
+++ b/py3-flake8.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-flake8
   description: the modular source code checker - pep8 pyflakes and co
   version: 6.1.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-flask-restful.yaml
+++ b/py3-flask-restful.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-flask-restful
   description: Simple framework for creating REST APIs
   version: 0.3.10
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-flask.yaml
+++ b/py3-flask.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-flask
   description: A simple framework for building complex web applications.
   version: 3.0.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-futurist.yaml
+++ b/py3-futurist.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-futurist
   description: Useful additions to futures, from the future.
   version: 3.0.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-glance-store.yaml
+++ b/py3-glance-store.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-glance-store
   description: OpenStack Image Service Store Library
   version: 4.8.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-glance.yaml
+++ b/py3-glance.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-glance
   description: OpenStack Image Service
   version: 29.0.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-gnocchiclient.yaml
+++ b/py3-gnocchiclient.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-gnocchiclient
   description: Python client library for Gnocchi
   version: 7.1.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-google-api-core.yaml
+++ b/py3-google-api-core.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-google-api-core
   description: Google API client core library
   version: 2.19.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-google-api-python-client.yaml
+++ b/py3-google-api-python-client.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-google-api-python-client
   description: Google API Client Library for Python
   version: 2.142.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-google-auth-httplib2.yaml
+++ b/py3-google-auth-httplib2.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-google-auth-httplib2
   description: Google Authentication Library - httplib2 transport
   version: 0.2.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-google-auth.yaml
+++ b/py3-google-auth.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-google-auth
   description: Google Authentication Library
   version: 2.34.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:


### PR DESCRIPTION
Packages updated:

* py3-cloudkitty
* py3-cmd2
* py3-confspirator
* py3-construct
* py3-coreapi
* py3-coreschema
* py3-cotyledon
* py3-croniter
* py3-cryptography
* py3-cursive
* py3-databases
* py3-datetimerange
* py3-debtcollector
* py3-decorator
* py3-defusedxml
* py3-designate
* py3-diskimage-builder
* py3-distro
* py3-django-appconf
* py3-django-compressor
* py3-django-debreach
* py3-django-pyscss
* py3-django-rest-swagger
* py3-django
* py3-djangorestframework
* py3-dnspython
* py3-docker
* py3-dogpile-cache
* py3-ecdsa
* py3-elasticsearch
* py3-elementpath
* py3-enmerkar
* py3-enum-compat
* py3-eventlet
* py3-exceptiongroup
* py3-falcon
* py3-fastapi
* py3-fasteners
* py3-fixtures
* py3-flake8
* py3-flask-restful
* py3-flask
* py3-futurist
* py3-glance-store
* py3-glance
* py3-gnocchiclient
* py3-google-api-core
* py3-google-api-python-client
* py3-google-auth-httplib2
* py3-google-auth
