### PR TITLE
Bump epoch for packages

### DIFF
--- a/kubernetes-entrypoint.yaml
+++ b/kubernetes-entrypoint.yaml
@@ -2,7 +2,7 @@ package:
   name: kubernetes-entrypoint
   description: Pod sequencing functionality for Kubernetes
   version: 0.3.1-43-g73814d3
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
 

--- a/liberasurecode.yaml
+++ b/liberasurecode.yaml
@@ -5,7 +5,7 @@ package:
   name: liberasurecode
   description: Erasure Code API library written in C with pluggable Erasure Code backends.
   version: 1.6.5
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
 

--- a/openvswitch.yaml
+++ b/openvswitch.yaml
@@ -5,7 +5,7 @@ package:
   name: openvswitch
   description: Open vSwitch
   version: 3.4.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-aiomysql.yaml
+++ b/py3-aiomysql.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-aiomysql
   description: MySQL driver for asyncio.
   version: 0.2.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-aiosqlite.yaml
+++ b/py3-aiosqlite.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-aiosqlite
   description: asyncio bridge to the standard sqlite3 module
   version: 0.17.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-alembic.yaml
+++ b/py3-alembic.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-alembic
   description: A database migration tool for SQLAlchemy.
   version: 1.13.2
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-amqp.yaml
+++ b/py3-amqp.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-amqp
   description: Low-level AMQP client for Python (fork of amqplib).
   version: 5.2.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-aniso8601.yaml
+++ b/py3-aniso8601.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-aniso8601
   description: A library for parsing ISO 8601 strings.
   version: 9.0.1
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-anyio.yaml
+++ b/py3-anyio.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-anyio
   description: High level compatibility layer for multiple asynchronous event loop implementations
   version: 4.4.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-aodh.yaml
+++ b/py3-aodh.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-aodh
   description: OpenStack Telemetry Alarming
   version: 19.0.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-aodhclient.yaml
+++ b/py3-aodhclient.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-aodhclient
   description: Python client library for Aodh
   version: 3.6.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-apscheduler.yaml
+++ b/py3-apscheduler.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-apscheduler
   description: In-process task scheduler with Cron-like capabilities
   version: 3.10.4
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-asgiref.yaml
+++ b/py3-asgiref.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-asgiref
   description: ASGI specs, helper code, and adapters
   version: 3.8.1
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-async-timeout.yaml
+++ b/py3-async-timeout.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-async-timeout
   description: Timeout context manager for asyncio programs
   version: 4.0.3
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-attrs.yaml
+++ b/py3-attrs.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-attrs
   description: Classes Without Boilerplate
   version: 24.2.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-autobahn.yaml
+++ b/py3-autobahn.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-autobahn
   description: WebSocket client & server library, WAMP real-time framework
   version: 24.4.2
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-automaton.yaml
+++ b/py3-automaton.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-automaton
   description: Friendly state machines for python.
   version: 3.2.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-autopage.yaml
+++ b/py3-autopage.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-autopage
   description: A library to provide automatic paging for console output
   version: 0.5.2
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-babel.yaml
+++ b/py3-babel.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-babel
   description: Internationalization utilities
   version: 2.16.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-barbican.yaml
+++ b/py3-barbican.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-barbican
   description: OpenStack Secure Key Management
   version: 19.0.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-bcrypt.yaml
+++ b/py3-bcrypt.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-bcrypt
   description: Modern password hashing for your software and your servers
   version: 4.0.1
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-blazar.yaml
+++ b/py3-blazar.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-blazar
   description: Reservation Service for OpenStack clouds
   version: 14.0.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-blinker.yaml
+++ b/py3-blinker.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-blinker
   description: Fast, simple object-to-object and broadcast signaling
   version: 1.8.2
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-boto3.yaml
+++ b/py3-boto3.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-boto3
   description: The AWS SDK for Python
   version: 1.35.5
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-botocore.yaml
+++ b/py3-botocore.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-botocore
   description: Low-level, data-driven core of boto 3.
   version: 1.35.5
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-cachetools.yaml
+++ b/py3-cachetools.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cachetools
   description: Extensible memoizing collections and decorators
   version: 5.5.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-castellan.yaml
+++ b/py3-castellan.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-castellan
   description: Generic Key Manager interface for OpenStack
   version: 5.1.1
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-ceilometer.yaml
+++ b/py3-ceilometer.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-ceilometer
   description: OpenStack Telemetry
   version: 23.0.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-certifi.yaml
+++ b/py3-certifi.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-certifi
   description: Python package for providing Mozilla's CA Bundle.
   version: 2024.12.14
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MPL-2.0
   dependencies:

--- a/py3-cffi.yaml
+++ b/py3-cffi.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cffi
   description: Foreign Function Interface for Python calling C code.
   version: 1.17.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-chardet.yaml
+++ b/py3-chardet.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-chardet
   description: Universal encoding detector for Python 3
   version: 5.2.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: LGPL-2.1-or-later
   dependencies:

--- a/py3-charset-normalizer.yaml
+++ b/py3-charset-normalizer.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-charset-normalizer
   description: The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet.
   version: 3.3.2
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-cinder.yaml
+++ b/py3-cinder.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cinder
   description: OpenStack Block Storage
   version: 25.0.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-click.yaml
+++ b/py3-click.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-click
   description: Composable command line interface toolkit
   version: 8.1.7
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-cliff.yaml
+++ b/py3-cliff.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cliff
   description: Command Line Interface Formulation Framework
   version: 4.7.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-cloudkitty.yaml
+++ b/py3-cloudkitty.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cloudkitty
   description: Rating as a Service component for OpenStack
   version: 21.0.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-cmd2.yaml
+++ b/py3-cmd2.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cmd2
   description: cmd2 - quickly build feature-rich and user-friendly interactive command line applications in Python
   version: 2.4.3
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-confspirator.yaml
+++ b/py3-confspirator.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-confspirator
   description: A config library for handling nested incode config groups.
   version: 0.3.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-construct.yaml
+++ b/py3-construct.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-construct
   description: A powerful declarative symmetric parser/builder for binary data
   version: 2.10.70
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-coreapi.yaml
+++ b/py3-coreapi.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-coreapi
   description: Python client library for Core API.
   version: 2.3.3
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-coreschema.yaml
+++ b/py3-coreschema.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-coreschema
   description: Core Schema.
   version: 0.0.4
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-cotyledon.yaml
+++ b/py3-cotyledon.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cotyledon
   description: Cotyledon provides a framework for defining long-running services.
   version: 1.7.3
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-croniter.yaml
+++ b/py3-croniter.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-croniter
   description: croniter provides iteration for datetime object with cron like format
   version: 2.0.7
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-cryptography.yaml
+++ b/py3-cryptography.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cryptography
   description: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
   version: 42.0.8
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
     - license: BSD-2-Clause

--- a/py3-cursive.yaml
+++ b/py3-cursive.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-cursive
   description: Cursive implements OpenStack-specific validation of digital signatures.
   version: 0.2.3
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-databases.yaml
+++ b/py3-databases.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-databases
   description: Async database support for Python.
   version: 0.9.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-datetimerange.yaml
+++ b/py3-datetimerange.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-datetimerange
   description: DateTimeRange is a Python library to handle a time range. e.g. check whether a time is within the time range, get the intersection of time ranges, truncate a time range, iterate through a time range, and so forth.
   version: 2.3.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: MIT
   dependencies:

--- a/py3-debtcollector.yaml
+++ b/py3-debtcollector.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-debtcollector
   description: A collection of Python deprecation patterns and strategies that help you collect your technical debt in a non-destructive manner.
   version: 3.0.0
-  epoch: 1
+  epoch: 2
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-decorator.yaml
+++ b/py3-decorator.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-decorator
   description: Decorators for Humans
   version: 5.1.1
-  epoch: 1
+  epoch: 2
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-defusedxml.yaml
+++ b/py3-defusedxml.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-defusedxml
   description: XML bomb protection for Python stdlib modules
   version: 0.7.1
-  epoch: 1
+  epoch: 2
   copyright:
     - license: PSF-2.0
   dependencies:


### PR DESCRIPTION
Packages updated:

* kubernetes-entrypoint
* liberasurecode
* openvswitch
* py3-aiomysql
* py3-aiosqlite
* py3-alembic
* py3-amqp
* py3-aniso8601
* py3-anyio
* py3-aodh
* py3-aodhclient
* py3-apscheduler
* py3-asgiref
* py3-async-timeout
* py3-attrs
* py3-autobahn
* py3-automaton
* py3-autopage
* py3-babel
* py3-barbican
* py3-bcrypt
* py3-blazar
* py3-blinker
* py3-boto3
* py3-botocore
* py3-cachetools
* py3-castellan
* py3-ceilometer
* py3-certifi
* py3-cffi
* py3-chardet
* py3-charset-normalizer
* py3-cinder
* py3-click
* py3-cliff
* py3-cloudkitty
* py3-cmd2
* py3-confspirator
* py3-construct
* py3-coreapi
* py3-coreschema
* py3-cotyledon
* py3-croniter
* py3-cryptography
* py3-cursive
* py3-databases
* py3-datetimerange
* py3-debtcollector
* py3-decorator
* py3-defusedxml
