### PR TITLE
Bump epoch for packages

### DIFF
--- a/py3-tenacity.yaml
+++ b/py3-tenacity.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-tenacity
   description: Retry code until it succeeds
   version: 8.3.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-testresources.yaml
+++ b/py3-testresources.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-testresources
   description: Testresources, a pyunit extension for managing expensive test resources
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
     - license: Apache-2.0

--- a/py3-testscenarios.yaml
+++ b/py3-testscenarios.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-testscenarios
   description: Testscenarios, a pyunit extension for dependency injection
   version: 0.5.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
     - license: Apache-2.0

--- a/py3-testtools.yaml
+++ b/py3-testtools.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-testtools
   description: Extensions to the Python standard library unit testing framework
   version: 2.7.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-text-unidecode.yaml
+++ b/py3-text-unidecode.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-text-unidecode
   description: The most basic Text - -Unidecode port
   version: 1.3
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Artistic-2.0
     - license: GPL-3.0-or-later

--- a/py3-toml.yaml
+++ b/py3-toml.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-toml
   description: Python Library for Tom's Obvious, Minimal Language
   version: 0.10.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-tooz.yaml
+++ b/py3-tooz.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-tooz
   description: Coordination library for distributed systems.
   version: 6.3.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-tosca-parser.yaml
+++ b/py3-tosca-parser.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-tosca-parser
   description: Parser for TOSCA Simple Profile in YAML.
   version: 2.11.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-trove.yaml
+++ b/py3-trove.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-trove
   description: OpenStack DBaaS
   version: 22.0.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-txaio.yaml
+++ b/py3-txaio.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-txaio
   description: Compatibility API between asyncio/Twisted/Trollius
   version: 23.1.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-typepy.yaml
+++ b/py3-typepy.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-typepy
   description: typepy is a Python library for variable type checker/validator/converter at a run time.
   version: 1.3.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-typing-extensions.yaml
+++ b/py3-typing-extensions.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-typing-extensions
   description: Backported and Experimental Type Hints for Python 3.8+
   version: 4.12.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: PSF-2.0
   dependencies:

--- a/py3-tzdata.yaml
+++ b/py3-tzdata.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-tzdata
   description: Provider of IANA time zone data
   version: 2024.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-tzlocal.yaml
+++ b/py3-tzlocal.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-tzlocal
   description: tzinfo object for the local timezone
   version: 5.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-ujson.yaml
+++ b/py3-ujson.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-ujson
   description: Ultra fast JSON encoder and decoder for Python
   version: 5.10.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-uritemplate.yaml
+++ b/py3-uritemplate.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-uritemplate
   description: Implementation of RFC 6570 URI Templates
   version: 4.1.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
     - license: BSD-2-Clause

--- a/py3-urllib3.yaml
+++ b/py3-urllib3.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-urllib3
   description: HTTP library with thread-safe connection pooling, file post, and more.
   version: 1.26.19
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-uvicorn.yaml
+++ b/py3-uvicorn.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-uvicorn
   description: The lightning-fast ASGI server.
   version: 0.17.6
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-vine.yaml
+++ b/py3-vine.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-vine
   description: Python promises.
   version: 5.1.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-vitrage.yaml
+++ b/py3-vitrage.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-vitrage
   description: The OpenStack RCA Service
   version: 13.0.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-voluptuous.yaml
+++ b/py3-voluptuous.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-voluptuous
   description: Python data validation library
   version: 0.15.2
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-warlock.yaml
+++ b/py3-warlock.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-warlock
   description: Python object model built on JSON schema and JSON patch.
   version: 2.0.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-wcwidth.yaml
+++ b/py3-wcwidth.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-wcwidth
   description: Measures the displayed width of unicode strings in a terminal
   version: 0.2.13
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-webob.yaml
+++ b/py3-webob.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-webob
   description: WSGI request and response object
   version: 1.8.8
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-websocket-client.yaml
+++ b/py3-websocket-client.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-websocket-client
   description: WebSocket client for Python with low level API options
   version: 1.8.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: Apache-2.0
   dependencies:

--- a/py3-websockify.yaml
+++ b/py3-websockify.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-websockify
   description: Websockify.
   version: 0.12.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-werkzeug.yaml
+++ b/py3-werkzeug.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-werkzeug
   description: The comprehensive WSGI web application library.
   version: 3.0.4
-  epoch: 0
+  epoch: 1
   copyright:
     - license: BSD-2-Clause
   dependencies:

--- a/py3-wsme.yaml
+++ b/py3-wsme.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-wsme
   description: Simplify the writing of REST APIs, and extend them with additional protocols.
   version: 0.12.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-xattr.yaml
+++ b/py3-xattr.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xattr
   description: Python wrapper for extended filesystem attributes
   version: 1.1.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-xmlschema.yaml
+++ b/py3-xmlschema.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xmlschema
   description: An XML Schema validator and decoder
   version: 2.5.1
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-xmltodict.yaml
+++ b/py3-xmltodict.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xmltodict
   description: Makes working with XML feel like you are working with JSON
   version: 0.13.0
-  epoch: 0
+  epoch: 1
   copyright:
     - license: MIT
   dependencies:

--- a/py3-xstatic-angular-bootstrap.yaml
+++ b/py3-xstatic-angular-bootstrap.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-angular-bootstrap
   description: Angular-Bootstrap 2.5.0 (XStatic packaging standard)
   version: 2.5.0.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-angular-fileupload.yaml
+++ b/py3-xstatic-angular-fileupload.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-angular-fileupload
   description: Angular-FileUpload 12.2.13 (XStatic packaging standard)
   version: 12.2.13.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-angular-gettext.yaml
+++ b/py3-xstatic-angular-gettext.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-angular-gettext
   description: Angular-Gettext 2.4.1 (XStatic packaging standard)
   version: 2.4.1.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-angular-lrdragndrop.yaml
+++ b/py3-xstatic-angular-lrdragndrop.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-angular-lrdragndrop
   description: Angular-lrdragndrop 1.0.2 (XStatic packaging standard)
   version: 1.0.2.6
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-angular-schema-form.yaml
+++ b/py3-xstatic-angular-schema-form.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-angular-schema-form
   description: Angular-Schema-Form 0.8.13 (XStatic packaging standard)
   version: 0.8.13.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-angular.yaml
+++ b/py3-xstatic-angular.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-angular
   description: Angular 1.8.2 (XStatic packaging standard)
   version: 1.8.2.2
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-bootstrap-datepicker.yaml
+++ b/py3-xstatic-bootstrap-datepicker.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-bootstrap-datepicker
   description: Bootstrap-Datepicker 1.4.0 (XStatic packaging standard)
   version: 1.4.0.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-bootstrap-scss.yaml
+++ b/py3-xstatic-bootstrap-scss.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-bootstrap-scss
   description: Bootstrap-SCSS 3.4.1 (XStatic packaging standard)
   version: 3.4.1.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-bootswatch.yaml
+++ b/py3-xstatic-bootswatch.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-bootswatch
   description: bootswatch 3.3.7 (XStatic packaging standard)
   version: 3.3.7.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-d3.yaml
+++ b/py3-xstatic-d3.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-d3
   description: D3 3.5.17 (XStatic packaging standard)
   version: 3.5.17.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-font-awesome.yaml
+++ b/py3-xstatic-font-awesome.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-font-awesome
   description: Font-Awesome 4.7.0 (XStatic packaging standard)
   version: 4.7.0.0
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-hogan.yaml
+++ b/py3-xstatic-hogan.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-hogan
   description: Hogan 2.0.0 (XStatic packaging standard)
   version: 2.0.0.3
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-jasmine.yaml
+++ b/py3-xstatic-jasmine.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-jasmine
   description: Jasmine 2.4.1 (XStatic packaging standard)
   version: 2.4.1.2
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-jquery-migrate.yaml
+++ b/py3-xstatic-jquery-migrate.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-jquery-migrate
   description: JQuery-Migrate 3.3.2 (XStatic packaging standard)
   version: 3.3.2.1
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-jquery-quicksearch.yaml
+++ b/py3-xstatic-jquery-quicksearch.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-jquery-quicksearch
   description: JQuery.quicksearch 2.0.3 (XStatic packaging standard)
   version: 2.0.3.2
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-jquery-tablesorter.yaml
+++ b/py3-xstatic-jquery-tablesorter.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-jquery-tablesorter
   description: JQuery.TableSorter 2.14.5 (XStatic packaging standard)
   version: 2.14.5.2
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-jquery-ui.yaml
+++ b/py3-xstatic-jquery-ui.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-jquery-ui
   description: jquery-ui 1.13.0 (XStatic packaging standard)
   version: 1.13.0.1
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-jquery.yaml
+++ b/py3-xstatic-jquery.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-jquery
   description: jQuery 3.5.1 (XStatic packaging standard)
   version: 3.5.1.1
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0

--- a/py3-xstatic-jsencrypt.yaml
+++ b/py3-xstatic-jsencrypt.yaml
@@ -5,7 +5,7 @@ package:
   name: py3-xstatic-jsencrypt
   description: JSEncrypt 2.3.1 (XStatic packaging standard)
   version: 2.3.1.1
-  epoch: 0
+  epoch: 1
   copyright:
   dependencies:
     provider-priority: 0


### PR DESCRIPTION
Packages updated:

* py3-tenacity
* py3-testresources
* py3-testscenarios
* py3-testtools
* py3-text-unidecode
* py3-toml
* py3-tooz
* py3-tosca-parser
* py3-trove
* py3-txaio
* py3-typepy
* py3-typing-extensions
* py3-tzdata
* py3-tzlocal
* py3-ujson
* py3-uritemplate
* py3-urllib3
* py3-uvicorn
* py3-vine
* py3-vitrage
* py3-voluptuous
* py3-warlock
* py3-wcwidth
* py3-webob
* py3-websocket-client
* py3-websockify
* py3-werkzeug
* py3-wsme
* py3-xattr
* py3-xmlschema
* py3-xmltodict
* py3-xstatic-angular-bootstrap
* py3-xstatic-angular-fileupload
* py3-xstatic-angular-gettext
* py3-xstatic-angular-lrdragndrop
* py3-xstatic-angular-schema-form
* py3-xstatic-angular
* py3-xstatic-bootstrap-datepicker
* py3-xstatic-bootstrap-scss
* py3-xstatic-bootswatch
* py3-xstatic-d3
* py3-xstatic-font-awesome
* py3-xstatic-hogan
* py3-xstatic-jasmine
* py3-xstatic-jquery-migrate
* py3-xstatic-jquery-quicksearch
* py3-xstatic-jquery-tablesorter
* py3-xstatic-jquery-ui
* py3-xstatic-jquery
* py3-xstatic-jsencrypt
